### PR TITLE
Fix/inbox resource

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+# `MANIFEST.in`
+recursive-include invenio_notify *.json *.js

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 # `MANIFEST.in`
-recursive-include invenio_notify *.json *.js
+recursive-include invenio_notify *.json *.js *.html

--- a/invenio_notify/blueprints.py
+++ b/invenio_notify/blueprints.py
@@ -1,5 +1,4 @@
-from flask import Blueprint, jsonify
-from invenio_records_resources.services.errors import PermissionDeniedError
+from flask import Blueprint
 
 blueprint = Blueprint(
     "notify",
@@ -7,20 +6,6 @@ blueprint = Blueprint(
     template_folder="templates",
 )
 
-rest_blueprint = Blueprint(
-    "notify_rest",
-    __name__,
-    url_prefix="/notify-rest",
-    template_folder="templates",
-)
-
-
-@rest_blueprint.errorhandler(PermissionDeniedError)
-def permission_denied_error(error):
-    """Handle permission denier error on record views."""
-    response = jsonify({"message": "Permission denied"})
-    response.status_code = 403
-    return response
 
 
 def create_notify_inbox_resource_api_bp(app):
@@ -29,3 +14,7 @@ def create_notify_inbox_resource_api_bp(app):
 
 def create_reviewer_resource_api_bp(app):
     return app.extensions["invenio-notify"].reviewer_resource.as_blueprint()
+
+
+def create_inbox_api_resource_bp(app):
+    return app.extensions["invenio-notify"].inbox_api_resource.as_blueprint()

--- a/invenio_notify/ext.py
+++ b/invenio_notify/ext.py
@@ -1,7 +1,7 @@
 from invenio_notify import config, cli
 from invenio_notify.blueprints import blueprint
-from invenio_notify.resources.config import NotifyInboxResourceConfig, ReviewerResourceConfig
-from invenio_notify.resources.resource import NotifyInboxResource, ReviewerResource
+from invenio_notify.resources.config import NotifyInboxResourceConfig, ReviewerResourceConfig, InboxApiResourceConfig
+from invenio_notify.resources.resource import NotifyInboxResource, ReviewerResource, InboxApiResource
 from invenio_notify.services.config import NotifyInboxServiceConfig, EndorsementServiceConfig, ReviewerMapServiceConfig, \
     ReviewerServiceConfig
 from invenio_notify.services.service import NotifyInboxService, EndorsementService, ReviewerMapService, ReviewerService
@@ -55,4 +55,8 @@ class InvenioNotify:
         self.reviewer_resource = ReviewerResource(
             service=self.reviewer_service,
             config=ReviewerResourceConfig,
+        )
+        self.inbox_api_resource = InboxApiResource(
+            service=self.notify_inbox_service,
+            config=InboxApiResourceConfig,
         )

--- a/invenio_notify/resources/config.py
+++ b/invenio_notify/resources/config.py
@@ -56,3 +56,9 @@ class ReviewerResourceConfig(BasicResourceConfig):
     routes['member'] = "/<record_id>/member"
     routes['members'] = "/<record_id>/members"
 
+
+class InboxApiResourceConfig(RecordResourceConfig):
+    """Configuration for the inbox API resource."""
+    blueprint_name = "inbox_api"
+    url_prefix = ""  # No prefix needed as route is defined directly
+

--- a/invenio_notify/resources/resource.py
+++ b/invenio_notify/resources/resource.py
@@ -164,7 +164,7 @@ class InboxApiResource(ErrorHandlersMixin, Resource):
     def create_url_rules(self):
         """Create the URL rules for the inbox resource."""
         return [
-            route("POST", "/inbox", self.receive_notification),
+            route("POST", "/notify/inbox", self.receive_notification),
         ]
 
     @request_data

--- a/invenio_notify/resources/resource.py
+++ b/invenio_notify/resources/resource.py
@@ -19,14 +19,16 @@ from .errors import ErrorHandlersMixin
 
 def require_inbox_oauth():
     """Decorator that requires OAuth authentication with inbox scope."""
+
     def decorator(f):
         from invenio_oauth2server import require_oauth_scopes, require_api_auth
         from invenio_notify.scopes import inbox_scope
-        
+
         # Apply decorators in correct order
         f = require_oauth_scopes(inbox_scope.id)(f)
         f = require_api_auth()(f)
         return f
+
     return decorator
 
 
@@ -190,11 +192,11 @@ class InboxApiResource(ErrorHandlersMixin, Resource):
     @require_inbox_oauth()
     def receive_notification(self):
         """Receive COAR notification via POST to /inbox."""
+        # TODO catch and handle exception if actor id is not url
         data = resource_requestctx.data
 
         if not data:
             return create_fail_response(constants.STATUS_BAD_REQUEST, "Request must be JSON")
-
 
         try:
             result = self.service.receive_notification(notification_raw=data)

--- a/invenio_notify/views/__init__.py
+++ b/invenio_notify/views/__init__.py
@@ -1,3 +1,2 @@
 
-# in order to make `invenio_base.api_blueprints`, api endpoints must be imported
-from invenio_notify.views.api_views import *  # noqa
+# Helper functions for API responses are available in api_views module

--- a/invenio_notify/views/api_views.py
+++ b/invenio_notify/views/api_views.py
@@ -1,4 +1,3 @@
-from flask import jsonify
 from coarnotify.server import COARNotifyReceipt
 from invenio_notify import constants
 
@@ -23,7 +22,7 @@ def create_default_msg_by_status(status):
 
 def create_fail_response(status, msg=None):
     msg = msg or create_default_msg_by_status(status)
-    return jsonify({"status": status, "message": msg}), status
+    return {"status": status, "message": msg}, status
 
 
 def response_coar_notify_receipt(receipt: COARNotifyReceipt, msg=None):
@@ -34,4 +33,4 @@ def response_coar_notify_receipt(receipt: COARNotifyReceipt, msg=None):
         data["location"] = receipt.location
 
     data["message"] = msg or create_default_msg_by_status(receipt.status)
-    return jsonify(data), receipt.status
+    return data, receipt.status

--- a/invenio_notify/webpack.py
+++ b/invenio_notify/webpack.py
@@ -2,7 +2,7 @@
 
 from invenio_assets.webpack import WebpackThemeBundle
 
-theme = WebpackThemeBundle(
+notify = WebpackThemeBundle(
     __name__,
     "assets",
     default="semantic-ui",

--- a/invenio_notify_test/test_views.py
+++ b/invenio_notify_test/test_views.py
@@ -24,7 +24,7 @@ def create_reviewer_map(db, user_id, reviewer_id):
 def send_inbox(client, token, notify_review_data):
     """Make an authenticated request to the inbox endpoint."""
     headers = {'Authorization': f'Bearer {token.access_token}'}
-    return client.post("/api/notify-rest/inbox", json=notify_review_data, headers=headers)
+    return client.post("/api/notify/inbox", json=notify_review_data, headers=headers)
 
 
 def create_notify_user(db, superuser_identity):
@@ -36,7 +36,7 @@ def create_notify_user(db, superuser_identity):
 
 def test_inbox_401(client):
     notify_review_data = inbox_fixture.create_notification_data('test-record-id')
-    response = client.post("/api/notify-rest/inbox", json=notify_review_data)
+    response = client.post("/api/notify/inbox", json=notify_review_data)
     assert response.status_code == 401
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ invenio_notify = "invenio_notify.records.models"
 oauth_noti = "invenio_notify.scopes:inbox_scope"
 
 [project.entry-points."invenio_assets.webpack"]
-invenio_notify = "invenio_notify.webpack:theme"
+invenio_notify = "invenio_notify.webpack:notify"
 
 [project.entry-points."invenio_jobs.jobs"]
 process_notify_inbox = "invenio_notify.jobs:ProcessNotifyInboxJob"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ process_notify_inbox = "invenio_notify.jobs:ProcessNotifyInboxJob"
 include-package-data = true
 
 [tool.setuptools.packages.find]
+where = ["."]
+exclude = ["build*", "dist*", "*.egg-info*"]
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ invenio_notify = "invenio_notify.ext:InvenioNotify"
 [project.entry-points."invenio_base.api_blueprints"]
 notify_inbox_resource = "invenio_notify.blueprints:create_notify_inbox_resource_api_bp"
 reviewer_resource = "invenio_notify.blueprints:create_reviewer_resource_api_bp"
-invenio_notify_rest = "invenio_notify.blueprints:rest_blueprint"
+inbox_api_resource = "invenio_notify.blueprints:create_inbox_api_resource_bp"
 
 [project.entry-points."invenio_base.apps"]
 invenio_notify = "invenio_notify.ext:InvenioNotify"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ invenio_notify = "invenio_notify.webpack:theme"
 [project.entry-points."invenio_jobs.jobs"]
 process_notify_inbox = "invenio_notify.jobs:ProcessNotifyInboxJob"
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.packages.find]
 
 


### PR DESCRIPTION
* Issue: #46 

The endpoint changes from "/api/notify-rest/inbox" -> "/api/notify/inbox"

This fixes the problem of the notify-rest/inbox endpoint not working when deploying with uwsgi.

It does so by refactoring it as a Resource endpoint.

It also adds packaging html/json/js with the module.

It also excludes the build directory from building to prevent recursive build directories adding up.